### PR TITLE
added manufacturer and tags to unit schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,14 @@ When building a UI with these schemas:
 
 ## Unit Schema
 
-The `unit.json` schema defines a complete piece of analog gear, including its ID, name, category, version, faceplate image, thumbnail image, dimensions, and an array of controls with their positions.
+The `unit.json` schema defines a complete piece of analog gear, including its ID, name, manufacturer, category, version, faceplate image, thumbnail image, dimensions, and an array of controls with their positions.
 
 ```json
 {
   "unitId": "example-unit",
   "name": "Example Unit",
+  "manufacturer": "Example Audio Company",
+  "tags": ["example", "demo", "test"],
   "version": "1.0.0",
   "category": "compressor",
   "faceplateImage": "https://example.com/images/faceplate.png",
@@ -221,6 +223,8 @@ Sample index.json structure:
     {
       "unitId": "la2a-compressor",
       "name": "LA-2A Compressor",
+      "manufacturer": "Teletronix/Universal Audio",
+      "tags": ["UA", "Universal Audio", "Teletronix", "optical", "tube", "vintage"],
       "category": "compressor",
       "version": "1.0.0",
       "schemaPath": "units/la2a-compressor-1.0.0.json",
@@ -229,6 +233,8 @@ Sample index.json structure:
     {
       "unitId": "api-560-eq",
       "name": "API 560 10-Band Graphic Equalizer",
+      "manufacturer": "Automated Processes Inc.",
+      "tags": ["API", "500 series", "graphic EQ", "10-band"],
       "category": "equalizer",
       "version": "1.0.0",
       "schemaPath": "units/api-560-eq-1.0.0.json",

--- a/schemas/unit.json
+++ b/schemas/unit.json
@@ -9,6 +9,17 @@
         "name": {
             "type": "string"
         },
+        "manufacturer": {
+            "type": "string",
+            "description": "The company or organization that manufactured the unit"
+        },
+        "tags": {
+            "type": "array",
+            "description": "Additional tags for improved search and categorization",
+            "items": {
+                "type": "string"
+            }
+        },
         "version": {
             "type": "string",
             "description": "Semantic version of the unit schema (e.g., 1.0.0)",
@@ -128,6 +139,7 @@
     "required": [
         "unitId",
         "name",
+        "manufacturer",
         "version",
         "category",
         "faceplateImage",

--- a/units/api-560-eq-1.0.0.json
+++ b/units/api-560-eq-1.0.0.json
@@ -1,6 +1,14 @@
 {
     "unitId": "api-560-eq",
     "name": "API 560 10-Band Graphic Equalizer",
+    "manufacturer": "Automated Processes Inc.",
+    "tags": [
+        "API",
+        "500 series",
+        "graphic EQ",
+        "10-band",
+        "hardware"
+    ],
     "version": "1.0.0",
     "category": "equalizer",
     "formFactor": "500-series",

--- a/units/index.json
+++ b/units/index.json
@@ -3,18 +3,36 @@
         {
             "unitId": "la2a-compressor",
             "name": "LA-2A Compressor",
+            "manufacturer": "Teletronix/Universal Audio",
             "category": "compressor",
             "version": "1.0.0",
             "schemaPath": "units/la2a-compressor-1.0.0.json",
-            "thumbnailImage": "assets/thumbnails/la2a-compressor-1.0.0.jpg"
+            "thumbnailImage": "assets/thumbnails/la2a-compressor-1.0.0.jpg",
+            "tags": [
+                "UA",
+                "Universal Audio",
+                "Teletronix",
+                "optical",
+                "tube",
+                "vintage",
+                "leveling amplifier"
+            ]
         },
         {
             "unitId": "api-560-eq",
             "name": "API 560 10-Band Graphic Equalizer",
+            "manufacturer": "Automated Processes Inc.",
             "category": "equalizer",
             "version": "1.0.0",
             "schemaPath": "units/api-560-eq-1.0.0.json",
-            "thumbnailImage": "assets/thumbnails/api-560-eq-1.0.0.jpg"
+            "thumbnailImage": "assets/thumbnails/api-560-eq-1.0.0.jpg",
+            "tags": [
+                "API",
+                "500 series",
+                "graphic EQ",
+                "10-band",
+                "hardware"
+            ]
         }
     ]
 }

--- a/units/la2a-compressor-1.0.0.json
+++ b/units/la2a-compressor-1.0.0.json
@@ -1,6 +1,16 @@
 {
     "unitId": "la2a-compressor",
     "name": "LA-2A Compressor",
+    "manufacturer": "Teletronix/Universal Audio",
+    "tags": [
+        "UA",
+        "Universal Audio",
+        "Teletronix",
+        "optical",
+        "tube",
+        "vintage",
+        "leveling amplifier"
+    ],
     "version": "1.0.0",
     "category": "compressor",
     "formFactor": "19-inch-rack",

--- a/utils/README.md
+++ b/utils/README.md
@@ -37,6 +37,8 @@ The script generates a `units/index.json` file with the following structure:
     {
       "unitId": "la2a-compressor",
       "name": "LA-2A Compressor",
+      "manufacturer": "Teletronix/Universal Audio",
+      "tags": ["UA", "Universal Audio", "Teletronix", "optical", "tube", "vintage"],
       "category": "compressor",
       "version": "1.0.0",
       "schemaPath": "units/la2a-compressor-1.0.0.json",
@@ -50,6 +52,8 @@ The script generates a `units/index.json` file with the following structure:
 The generated index includes the following metadata for each unit:
 - `unitId`: The unique identifier for the unit
 - `name`: The human-readable name of the unit
+- `manufacturer`: The company that manufactured the unit
+- `tags`: Array of additional searchable tags (optional)
 - `category`: The category of the unit (e.g., "compressor", "equalizer")
 - `version`: The semantic version of the unit
 - `schemaPath`: The relative path to the unit's JSON file
@@ -105,9 +109,12 @@ is_valid, errors = validator.validate_unit_file('path/to/unit.json')
 unit_data = {
     "unitId": "my-unit",
     "name": "My Unit",
+    "manufacturer": "My Audio Company",
+    "tags": ["custom", "example", "demo"],
     "version": "1.0.0",
     "category": "compressor",
     "faceplateImage": "https://example.com/my-unit.png",
+    "thumbnailImage": "https://example.com/my-unit-thumbnail.png",
     "width": 800,
     "height": 300,
     "controls": [

--- a/utils/generate_index.py
+++ b/utils/generate_index.py
@@ -60,11 +60,16 @@ class IndexGenerator:
                 unit_info = {
                     "unitId": unit_data.get("unitId"),
                     "name": unit_data.get("name"),
+                    "manufacturer": unit_data.get("manufacturer"),
                     "category": unit_data.get("category"),
                     "version": unit_data.get("version"),
                     "schemaPath": str(file_path.relative_to(self.root_dir)),
                     "thumbnailImage": unit_data.get("thumbnailImage"),
                 }
+
+                # Add optional tags if available
+                if "tags" in unit_data:
+                    unit_info["tags"] = unit_data["tags"]
 
                 # Validate that we have all required fields
                 if not all(unit_info.values()):


### PR DESCRIPTION
Want to be able to search for a wider set of terms in the client. Added manufacturer and a "tags" array so that people can search for "API" or "graphic EQ" or "vintage" and get results.