### PR TITLE
updating knobs to use degrees of rotation, including stepped knobs

### DIFF
--- a/schemas/controls/knob.json
+++ b/schemas/controls/knob.json
@@ -3,91 +3,46 @@
     "type": "object",
     "required": [
         "type",
+        "value",
         "startAngle",
-        "endAngle"
+        "endAngle",
+        "image"
     ],
     "properties": {
         "type": {
             "const": "knob"
         },
-        "min": {
-            "type": "number"
+        "value": {
+            "type": "number",
+            "description": "Current value of the knob, mapped to the angle range"
         },
-        "max": {
-            "type": "number"
+        "startAngle": {
+            "type": "number",
+            "description": "Starting angle in degrees (0-360) where the knob begins its range"
         },
-        "step": {
-            "type": [
-                "number",
-                "null"
-            ]
+        "endAngle": {
+            "type": "number",
+            "description": "Ending angle in degrees (0-360) where the knob ends its range"
         },
         "steps": {
             "type": "array",
-            "description": "Array of discrete positions for stepped knobs (takes precedence over min/max/step)",
+            "description": "Array of rotation degrees (0-360) for stepped knobs",
             "items": {
-                "oneOf": [
-                    {
-                        "type": [
-                            "string",
-                            "number"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "value",
-                            "degree"
-                        ],
-                        "properties": {
-                            "value": {
-                                "type": [
-                                    "string",
-                                    "number"
-                                ],
-                                "description": "The parameter value at this step"
-                            },
-                            "degree": {
-                                "type": "number",
-                                "description": "Rotation degree for this step (0-360)",
-                                "minimum": 0,
-                                "maximum": 360
-                            },
-                            "label": {
-                                "type": "string",
-                                "description": "Optional display label for this step"
-                            }
-                        }
-                    }
-                ]
+                "type": "number",
+                "minimum": 0,
+                "maximum": 360
             },
             "minItems": 1
-        },
-        "startAngle": {
-            "type": "number"
-        },
-        "endAngle": {
-            "type": "number"
-        },
-        "value": {
-            "type": [
-                "number",
-                "string"
-            ]
         },
         "currentStepIndex": {
             "type": "integer",
             "description": "Index of the current step in the steps array (only used with steps)",
             "minimum": 0
         },
-        "zIndex": {
-            "type": "integer",
-            "default": 0
-        },
         "image": {
             "type": "string",
             "format": "uri",
-            "description": "URI to the image representing this specific knob's visual appearance"
+            "description": "URI to the knob image"
         }
     },
     "allOf": [
@@ -100,21 +55,6 @@
             "then": {
                 "required": [
                     "currentStepIndex"
-                ]
-            }
-        },
-        {
-            "if": {
-                "not": {
-                    "required": [
-                        "steps"
-                    ]
-                }
-            },
-            "then": {
-                "required": [
-                    "min",
-                    "max"
                 ]
             }
         }

--- a/units/index.json
+++ b/units/index.json
@@ -2,20 +2,18 @@
     "units": [
         {
             "unitId": "la2a-compressor",
-            "name": "LA-2A Compressor",
-            "manufacturer": "Teletronix/Universal Audio",
+            "name": "LA-2A Tube Compressor",
+            "manufacturer": "Universal Audio",
             "category": "compressor",
             "version": "1.0.0",
             "schemaPath": "units/la2a-compressor-1.0.0.json",
             "thumbnailImage": "assets/thumbnails/la2a-compressor-1.0.0.jpg",
             "tags": [
-                "UA",
-                "Universal Audio",
-                "Teletronix",
-                "optical",
+                "compressor",
                 "tube",
+                "optical",
                 "vintage",
-                "leveling amplifier"
+                "hardware"
             ]
         },
         {

--- a/units/la2a-compressor-1.0.0.json
+++ b/units/la2a-compressor-1.0.0.json
@@ -1,15 +1,13 @@
 {
     "unitId": "la2a-compressor",
-    "name": "LA-2A Compressor",
-    "manufacturer": "Teletronix/Universal Audio",
+    "name": "LA-2A Tube Compressor",
+    "manufacturer": "Universal Audio",
     "tags": [
-        "UA",
-        "Universal Audio",
-        "Teletronix",
-        "optical",
+        "compressor",
         "tube",
+        "optical",
         "vintage",
-        "leveling amplifier"
+        "hardware"
     ],
     "version": "1.0.0",
     "category": "compressor",
@@ -24,40 +22,53 @@
             "label": "Gain Reduction",
             "type": "knob",
             "position": {
-                "x": 0.2,
-                "y": 0.3
+                "x": 0.1,
+                "y": 0.5
             },
-            "min": 0,
-            "max": 100,
-            "startAngle": 30,
-            "endAngle": 330,
-            "value": 40,
-            "zIndex": 1,
-            "image": "assets/controls/knobs/bakelite-lg-black.png"
+            "value": 180,
+            "startAngle": 160,
+            "endAngle": 200,
+            "steps": [
+                160,
+                180,
+                200
+            ],
+            "currentStepIndex": 1,
+            "image": "assets/controls/knobs/knob-sm-black.png"
         },
         {
-            "id": "output-gain",
-            "label": "Output Gain",
+            "id": "peak-reduction",
+            "label": "Peak Reduction",
             "type": "knob",
             "position": {
-                "x": 0.5,
-                "y": 0.3
+                "x": 0.2,
+                "y": 0.5
             },
-            "min": 0,
-            "max": 100,
+            "value": 180,
             "startAngle": 30,
             "endAngle": 330,
-            "value": 50,
-            "zIndex": 1,
-            "image": "assets/controls/knobs/bakelite-lg-black.png"
+            "image": "assets/controls/knobs/knob-sm-black.png"
         },
         {
-            "id": "response",
-            "label": "Response",
+            "id": "gain",
+            "label": "Gain",
+            "type": "knob",
+            "position": {
+                "x": 0.3,
+                "y": 0.5
+            },
+            "value": 180,
+            "startAngle": 30,
+            "endAngle": 330,
+            "image": "assets/controls/knobs/knob-sm-black.png"
+        },
+        {
+            "id": "comp-lim",
+            "label": "Comp/Lim",
             "type": "switch",
             "position": {
-                "x": 0.8,
-                "y": 0.3
+                "x": 0.4,
+                "y": 0.5
             },
             "options": [
                 {
@@ -82,47 +93,15 @@
                 }
             ],
             "currentIndex": 1,
-            "image": "assets/controls/switches/chrome-lg-sprite.png"
-        },
-        {
-            "id": "meter-selector",
-            "label": "Meter",
-            "type": "knob",
-            "position": {
-                "x": 0.8,
-                "y": 0.6
-            },
-            "steps": [
-                {
-                    "value": "+10",
-                    "degree": 60,
-                    "label": "+10 dB"
-                },
-                {
-                    "value": "GR",
-                    "degree": 300,
-                    "label": "Gain Reduction"
-                },
-                {
-                    "value": "+4",
-                    "degree": 180,
-                    "label": "+4 dB"
-                }
-            ],
-            "currentStepIndex": 1,
-            "startAngle": 30,
-            "endAngle": 330,
-            "value": "GR",
-            "zIndex": 1,
-            "image": "assets/controls/knobs/bakelite-lg-black.png"
+            "image": "assets/controls/switches/switch-sm-black.png"
         },
         {
             "id": "power",
             "label": "Power",
             "type": "switch",
             "position": {
-                "x": 0.9,
-                "y": 0.8
+                "x": 0.6,
+                "y": 0.5
             },
             "options": [
                 {
@@ -147,7 +126,7 @@
                 }
             ],
             "currentIndex": 0,
-            "image": "assets/controls/switches/chrome-lg-sprite.png"
+            "image": "assets/controls/switches/switch-sm-red.png"
         }
     ]
 }


### PR DESCRIPTION
- knobs all have startAngle and endAngle represented as degrees of rotation
- values are now also the current number of degrees of a rotation
- stepped knobs are an array of degrees of rotation
- updated La2a to reflect these changes